### PR TITLE
Adjust sendMessage signature to match latest

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -16,7 +16,7 @@ export const runtime = {
       disconnect: jest.fn(),
     };
   }),
-  sendMessage: jest.fn((message, cb) => {
+  sendMessage: jest.fn((extensionId, message, options, cb) => {
     onMessageListeners.forEach((listener) => listener(message));
     if (cb !== undefined) {
       return cb();


### PR DESCRIPTION
Chrome has adjusted this signature so when this is called with an extensionId this mock fails an error 

TypeError: cb is not a function